### PR TITLE
🔨 [FIX] status update and window close logic

### DIFF
--- a/app/services/exemplar_service.py
+++ b/app/services/exemplar_service.py
@@ -91,7 +91,8 @@ class ExemplarService:
         try:
             exemplar = self.get_by_id(id)
             if isinstance(exemplar, Exemplar):
-                exemplar.status = status
+                if isinstance(status, int):
+                    exemplar.status = Status(value=status)
                 if self._exemplar_repo.update_status(exemplar):
                     return True
                 raise Exception("Failed to update exemplar status")

--- a/app/ui/pages/book/book_add_page.py
+++ b/app/ui/pages/book/book_add_page.py
@@ -191,6 +191,7 @@ class BookAddPage(ctk.CTkToplevel):
             text="No",
             command=lambda: [
                 confirm_window.destroy(),
+                self.destroy()
             ]
         ).pack(side="right", padx=10)
         


### PR DESCRIPTION
Ensure status is set using the Status enum in ExemplarService when an integer is provided. Also, close the BookAddPage window when the user cancels the confirmation dialog.